### PR TITLE
Initial Swift implementation of StrapMetrics for event logging

### DIFF
--- a/StrapMetrics.xcodeproj/project.pbxproj
+++ b/StrapMetrics.xcodeproj/project.pbxproj
@@ -1,0 +1,417 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		88A2BD831A9E815600D6CA75 /* StrapMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 88A2BD821A9E815600D6CA75 /* StrapMetrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		88A2BD891A9E815600D6CA75 /* StrapMetrics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88A2BD7D1A9E815600D6CA75 /* StrapMetrics.framework */; };
+		88A2BD901A9E815600D6CA75 /* StrapMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A2BD8F1A9E815600D6CA75 /* StrapMetricsTests.swift */; };
+		88A2BD9A1A9E817900D6CA75 /* StrapMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A2BD991A9E817900D6CA75 /* StrapMetrics.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		88A2BD8A1A9E815600D6CA75 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 88A2BD741A9E815600D6CA75 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 88A2BD7C1A9E815600D6CA75;
+			remoteInfo = StrapMetrics;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		88A2BD7D1A9E815600D6CA75 /* StrapMetrics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StrapMetrics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		88A2BD811A9E815600D6CA75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		88A2BD821A9E815600D6CA75 /* StrapMetrics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StrapMetrics.h; sourceTree = "<group>"; };
+		88A2BD881A9E815600D6CA75 /* StrapMetricsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StrapMetricsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		88A2BD8E1A9E815600D6CA75 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		88A2BD8F1A9E815600D6CA75 /* StrapMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrapMetricsTests.swift; sourceTree = "<group>"; };
+		88A2BD991A9E817900D6CA75 /* StrapMetrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrapMetrics.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		88A2BD791A9E815600D6CA75 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		88A2BD851A9E815600D6CA75 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88A2BD891A9E815600D6CA75 /* StrapMetrics.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		88A2BD731A9E815600D6CA75 = {
+			isa = PBXGroup;
+			children = (
+				88A2BD7F1A9E815600D6CA75 /* StrapMetrics */,
+				88A2BD8C1A9E815600D6CA75 /* StrapMetricsTests */,
+				88A2BD7E1A9E815600D6CA75 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		88A2BD7E1A9E815600D6CA75 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				88A2BD7D1A9E815600D6CA75 /* StrapMetrics.framework */,
+				88A2BD881A9E815600D6CA75 /* StrapMetricsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		88A2BD7F1A9E815600D6CA75 /* StrapMetrics */ = {
+			isa = PBXGroup;
+			children = (
+				88A2BD821A9E815600D6CA75 /* StrapMetrics.h */,
+				88A2BD801A9E815600D6CA75 /* Supporting Files */,
+				88A2BD991A9E817900D6CA75 /* StrapMetrics.swift */,
+			);
+			path = StrapMetrics;
+			sourceTree = "<group>";
+		};
+		88A2BD801A9E815600D6CA75 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				88A2BD811A9E815600D6CA75 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		88A2BD8C1A9E815600D6CA75 /* StrapMetricsTests */ = {
+			isa = PBXGroup;
+			children = (
+				88A2BD8F1A9E815600D6CA75 /* StrapMetricsTests.swift */,
+				88A2BD8D1A9E815600D6CA75 /* Supporting Files */,
+			);
+			path = StrapMetricsTests;
+			sourceTree = "<group>";
+		};
+		88A2BD8D1A9E815600D6CA75 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				88A2BD8E1A9E815600D6CA75 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		88A2BD7A1A9E815600D6CA75 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88A2BD831A9E815600D6CA75 /* StrapMetrics.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		88A2BD7C1A9E815600D6CA75 /* StrapMetrics */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 88A2BD931A9E815600D6CA75 /* Build configuration list for PBXNativeTarget "StrapMetrics" */;
+			buildPhases = (
+				88A2BD781A9E815600D6CA75 /* Sources */,
+				88A2BD791A9E815600D6CA75 /* Frameworks */,
+				88A2BD7A1A9E815600D6CA75 /* Headers */,
+				88A2BD7B1A9E815600D6CA75 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StrapMetrics;
+			productName = StrapMetrics;
+			productReference = 88A2BD7D1A9E815600D6CA75 /* StrapMetrics.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		88A2BD871A9E815600D6CA75 /* StrapMetricsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 88A2BD961A9E815600D6CA75 /* Build configuration list for PBXNativeTarget "StrapMetricsTests" */;
+			buildPhases = (
+				88A2BD841A9E815600D6CA75 /* Sources */,
+				88A2BD851A9E815600D6CA75 /* Frameworks */,
+				88A2BD861A9E815600D6CA75 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				88A2BD8B1A9E815600D6CA75 /* PBXTargetDependency */,
+			);
+			name = StrapMetricsTests;
+			productName = StrapMetricsTests;
+			productReference = 88A2BD881A9E815600D6CA75 /* StrapMetricsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		88A2BD741A9E815600D6CA75 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0620;
+				ORGANIZATIONNAME = "Back, Jonah";
+				TargetAttributes = {
+					88A2BD7C1A9E815600D6CA75 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+					88A2BD871A9E815600D6CA75 = {
+						CreatedOnToolsVersion = 6.2;
+					};
+				};
+			};
+			buildConfigurationList = 88A2BD771A9E815600D6CA75 /* Build configuration list for PBXProject "StrapMetrics" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 88A2BD731A9E815600D6CA75;
+			productRefGroup = 88A2BD7E1A9E815600D6CA75 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				88A2BD7C1A9E815600D6CA75 /* StrapMetrics */,
+				88A2BD871A9E815600D6CA75 /* StrapMetricsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		88A2BD7B1A9E815600D6CA75 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		88A2BD861A9E815600D6CA75 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		88A2BD781A9E815600D6CA75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88A2BD9A1A9E817900D6CA75 /* StrapMetrics.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		88A2BD841A9E815600D6CA75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				88A2BD901A9E815600D6CA75 /* StrapMetricsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		88A2BD8B1A9E815600D6CA75 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 88A2BD7C1A9E815600D6CA75 /* StrapMetrics */;
+			targetProxy = 88A2BD8A1A9E815600D6CA75 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		88A2BD911A9E815600D6CA75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		88A2BD921A9E815600D6CA75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		88A2BD941A9E815600D6CA75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = StrapMetrics/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		88A2BD951A9E815600D6CA75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = StrapMetrics/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		88A2BD971A9E815600D6CA75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StrapMetricsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		88A2BD981A9E815600D6CA75 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StrapMetricsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		88A2BD771A9E815600D6CA75 /* Build configuration list for PBXProject "StrapMetrics" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				88A2BD911A9E815600D6CA75 /* Debug */,
+				88A2BD921A9E815600D6CA75 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		88A2BD931A9E815600D6CA75 /* Build configuration list for PBXNativeTarget "StrapMetrics" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				88A2BD941A9E815600D6CA75 /* Debug */,
+				88A2BD951A9E815600D6CA75 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		88A2BD961A9E815600D6CA75 /* Build configuration list for PBXNativeTarget "StrapMetricsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				88A2BD971A9E815600D6CA75 /* Debug */,
+				88A2BD981A9E815600D6CA75 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 88A2BD741A9E815600D6CA75 /* Project object */;
+}

--- a/StrapMetrics.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/StrapMetrics.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:StrapMetrics.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/StrapMetrics/Info.plist
+++ b/StrapMetrics/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.straphq.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/StrapMetrics/StrapMetrics.h
+++ b/StrapMetrics/StrapMetrics.h
@@ -1,0 +1,19 @@
+//
+//  StrapMetrics.h
+//  StrapMetrics
+//
+//  Created by Back, Jonah on 2/25/15.
+//  Copyright (c) 2015 Back, Jonah. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for StrapMetrics.
+FOUNDATION_EXPORT double StrapMetricsVersionNumber;
+
+//! Project version string for StrapMetrics.
+FOUNDATION_EXPORT const unsigned char StrapMetricsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <StrapMetrics/PublicHeader.h>
+
+

--- a/StrapMetrics/StrapMetrics.swift
+++ b/StrapMetrics/StrapMetrics.swift
@@ -1,0 +1,66 @@
+//
+//  StrapMetrics.swift
+//  StrapMetrics
+
+import Foundation
+
+public class StrapMetrics {
+    
+    let defaults = NSUserDefaults.standardUserDefaults()
+    let session: NSURLSession
+    let URL = "https://api.straphq.com/create/visit/with/"
+    let appId: NSString
+    let resolution:  CGRect
+    let userAgent: NSString
+    
+    public init(appId: NSString, resolution: CGRect) {
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        session = NSURLSession(configuration: configuration);
+        self.appId = appId
+        self.resolution = resolution
+        self.userAgent = "APPLEWATCH/1.0"
+    }
+    
+    private func getResolutionString() -> NSString {
+        let screenWidth = Int(resolution.width)
+        let screenHeight = Int(resolution.height)
+        
+        return String(format: "%dx%d", arguments: [screenWidth, screenHeight])
+    }
+    
+    private func getTimezoneOffsetString() -> NSString {
+        let tz_offset = (NSTimeZone.localTimeZone().secondsFromGMT / 3600)
+        return String(format: "%lz", arguments: [tz_offset])
+    }
+    
+    private func buildBaseQuery() -> NSString {
+        let query = "app_id=" + appId
+            + "&resolution=" + getResolutionString()
+            + "&useragent=" + "APPLEWATCH/1.0"
+            + "&visitor_id=" + UIDevice.currentDevice().identifierForVendor.UUIDString
+            + "&visitor_timeoffset=" + getTimezoneOffsetString()
+        
+        return query
+    }
+    
+    private func getEventQuery(eventName: NSString) -> NSString {
+        let query = buildBaseQuery() + "&action_url=" + eventName
+        return query
+    }
+    
+    private func sendStrapApiRequest(query: NSString) {
+        let request = NSMutableURLRequest(URL: NSURL(string: URL)!)
+        let data = query.dataUsingEncoding(NSUTF8StringEncoding)
+        request.HTTPBody = data
+        request.HTTPMethod = "POST"
+        let task = session.dataTaskWithRequest(request, completionHandler: { (data, response, error) -> Void in
+            //TODO add error handling
+        })
+        task.resume()
+    }
+    
+    public func logEvent(eventName: NSString) {
+        sendStrapApiRequest(getEventQuery(eventName))
+    }
+    
+}

--- a/StrapMetricsTests/Info.plist
+++ b/StrapMetricsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.straphq.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StrapMetricsTests/StrapMetricsTests.swift
+++ b/StrapMetricsTests/StrapMetricsTests.swift
@@ -1,0 +1,36 @@
+//
+//  StrapMetricsTests.swift
+//  StrapMetricsTests
+//
+//  Created by Back, Jonah on 2/25/15.
+//  Copyright (c) 2015 Back, Jonah. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class StrapMetricsTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
A basic implementation of a Swift API for using StrapMetrics. By importing this framework into an app, users can log events to their strap application. 

Usage:

``` swift
let strap = StrapMetrics(appId: "<insert id here>", resolution: WKInterfaceDevice.currentDevice().screenBounds )
strap.logEvent("/refresh")
```
